### PR TITLE
Add CSSJanus support

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -54,6 +54,7 @@
         <exclude-pattern>ToolforgeBundle.php</exclude-pattern>
         <properties>
             <property name="rootNamespaces" type="array">
+                <element key="Asset" value="Wikimedia\ToolforgeBundle\Asset"/>
                 <element key="Controller" value="Wikimedia\ToolforgeBundle\Controller"/>
                 <element key="DependencyInjection" value="Wikimedia\ToolforgeBundle\DependencyInjection"/>
                 <element key="Resources" value="Wikimedia\ToolforgeBundle\Resources"/>

--- a/Asset/CssJanusPackage.php
+++ b/Asset/CssJanusPackage.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wikimedia\ToolforgeBundle\Asset;
+
+use CSSJanus;
+use Krinkle\Intuition\Intuition;
+use Symfony\Component\Asset\Context\ContextInterface;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class CssJanusPackage extends PathPackage
+{
+
+    /** @var Intuition */
+    protected $intuition;
+
+    /** @var string */
+    protected $kernelProjectDir;
+
+    public function __construct(
+        VersionStrategyInterface $versionStrategy,
+        Intuition $intuition,
+        string $kernelProjectDir,
+        ?ContextInterface $context = null
+    ) {
+        parent::__construct('', $versionStrategy, $context);
+        $this->kernelProjectDir = $kernelProjectDir;
+        $this->intuition = $intuition;
+    }
+
+    /**
+     * Returns an absolute or root-relative public path.
+     *
+     * @param string $path A path
+     *
+     * @return string The public path
+     */
+    public function getUrl($path) :string // @codingStandardsIgnoreLine
+    {
+        $ext = pathinfo($path, PATHINFO_EXTENSION);
+        $isRtl = $this->intuition->isRtl();
+        $ltrCssUrl = parent::getUrl($path);
+        if ('css' !== $ext || !$isRtl) {
+            // Do no further processing if this isn't CSS and RTL.
+            return $ltrCssUrl;
+        }
+
+        // Get the LTR filename.
+        $versionedPath = $this->getVersionStrategy()->applyVersion($path);
+        $ltrCssFilename = $this->kernelProjectDir.'/public/'.$versionedPath;
+
+        // Construct the RTL URL and filename.
+        $rtlSuffix = '_rtl.css';
+        $rtlCssUrl = substr($ltrCssUrl, 0, -4).$rtlSuffix;
+        $rtlCssFilename = substr($ltrCssFilename, 0, -4).$rtlSuffix;
+
+        // If the RTL CSS file already exists, return its URL.
+        if (file_exists($rtlCssFilename)) {
+            return $rtlCssUrl;
+        }
+
+        // Otherwise, generate the RTL CSS file.
+        // The file generation could also have been done externally by the Encore processor.
+        $fileSystem = new Filesystem();
+        $ltrCss = file_get_contents($ltrCssFilename);
+        $rtlCss = CSSJanus::transform($ltrCss);
+        $fileSystem->dumpFile($rtlCssFilename, $rtlCss);
+
+        // Return the new RTL CSS URL.
+        return $rtlCssUrl;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Still to come:
 * [Installation](#installation)
 * [Configuration](#configuration)
   * [OAuth](#oauth)
-  * [Internationalization (Intuition and jQuery.i18n)](#internationalization-intuition-and-jqueryi18n)
+  * [Internationalization](#internationalization) (in PHP, Javascript, and CSS)
 * [Examples](#examples)
 * [License](#license)
 
@@ -98,7 +98,10 @@ add a `logged_in_user` key to your `config/packages/toolforge.yml` file, e.g.:
       oauth:
         logged_in_user: '%env(LOGGED_IN_USER)%'
 
-### Internationalization (Intuition and jQuery.i18n)
+### Internationalization
+
+This section explains how to incorporate the bundle's usage of
+the Intuition, jQuery.i18n, & CSSJanus libraries.
 
 #### 1. PHP
 
@@ -134,6 +137,30 @@ And this to your HTML template (before your `app.js`):
     {% include '@toolforge/i18n.html.twig' %}
 
 Then you can get i18n messages with `$.i18n( 'msg-name', paramOne, paramTwo )`
+
+#### 3. CSS
+
+The [CSSJanus library](https://github.com/cssjanus/php-cssjanus)
+is used to flip CSS from the default left-to-right writing direction
+to right-to-left when a request is made in a relevant language
+(based on Intuition's idea of that; see above).
+
+This is done via an Asset 'Package' which is registered as the `assets.toolforge_package` service.
+
+To use it, add the following to your `services.yaml` file:
+
+    assets._default_package: '@assets.toolforge_package'
+
+Then, when you use something like this in your Twig template:
+
+    <link rel="stylesheet" type="text/css" href="{{ asset('assets/app.css') }}" /> 
+
+the bundle will automatically change the output URL
+based on the current language's direction.
+It will also look for an `_rtl.css` stylesheet and generate one if required
+(this requires the web server user to have write access to the `public/assets/` directory).
+
+@TODO Add a Encore plugin that will generate the equivalent file.
 
 ## Examples
 

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -26,3 +26,11 @@ services:
       - "@session"
       - "%toolforge.intuition.domain%"
     tags: [ "twig.extension" ]
+
+  assets.toolforge_package:
+    class: Wikimedia\ToolforgeBundle\Asset\CssJanusPackage
+    arguments:
+      - "@assets._version__default"
+      - '@Krinkle\Intuition\Intuition'
+      - "%kernel.project_dir%"
+      - "@assets.context"

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
         }
     },
     "require": {
-        "symfony/http-kernel": "^4.1",
-        "symfony/routing": "^4.1",
-        "symfony/config": "^4.1",
-        "symfony/twig-bridge": "^4.1",
+        "cssjanus/cssjanus": "^1.2",
         "krinkle/intuition": "^1.1",
+        "symfony/config": "^4.1",
+        "symfony/http-kernel": "^4.1",
+        "symfony/filesystem": "^4.1",
+        "symfony/routing": "^4.1",
+        "symfony/twig-bridge": "^4.1",
         "mediawiki/oauthclient": "^0.1"
     },
     "require-dev": {


### PR DESCRIPTION
This adds the first part of support for CSSJanus: the asset URL
constructing part. It also adds auto-generation of RTL stylesheets
but this will also be possible to do not at runtime, with Encore.

Bug: GH#1