### PR TITLE
Remove Symfony 4.2 deprecations

### DIFF
--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Wikimedia\ToolforgeBundle\Controller;
 
 use MediaWiki\OAuthClient\Client;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
 
-class AuthController extends Controller
+class AuthController extends AbstractController
 {
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,9 +15,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $builder = new TreeBuilder();
-        $root = $builder->root('toolforge');
-        $root
+        $builder = new TreeBuilder('toolforge');
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('oauth')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
This removes two deprecated idioms, that will not be available
after Symfony 4.2.

Bug: https://phabricator.wikimedia.org/T212270