### PR TITLE
Add deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ or on [Phabricator](https://phabricator.wikimedia.org/tag/community-tech) (tagge
   * [Internationalization (Intuition and jQuery.i18n)](#internationalization-intuition-and-jqueryi18n)
   * [PHP Code Sniffer](#php-code-sniffer)
   * [Wikimedia UI styles](#wikimedia-ui-styles)
+  * [Deployment script](#deployment-script)
 * [Examples](#examples)
 * [License](#license)
 
@@ -179,6 +180,22 @@ And then import both it and the bundle's CSS file for it
 
     @import '../node_modules/wikimedia-ui-base/wikimedia-ui-base.less';
     @import '../vendor/wikimedia/toolforge-bundle/Resources/assets/wikimedia-base.less';
+
+### Deployment script
+
+The bundle comes with a deployment script for use on Toolforge
+where an application is run on the Kubernetes cluster.
+
+It should be added to your tool's crontab to run e.g. every ten minutes:
+
+    */10 * * * * /usr/bin/jsub -once -quiet /data/project/<toolname>/vendor/wikimedia/toolforge-bundle/bin/deploy.sh prod /data/project/<toolname>/<app-dir>/
+
+* The first argument is either `prod` or `dev`,
+  depending on whether you want to run the highest tagged version,
+  or the lastest master branch.
+* The second is the path to the tool's top-level directory,
+  which is usually either the tool's home directory or a directory within it
+  (e.g. `/data/project/<toolname>/app`).
 
 ## Examples
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [[ -z $1 || -z $2 ]]; then
+    echo "USAGE: $0 [prod|dev] <app-dir>"
+    exit 1
+fi
+
+## Get CLI parameters.
+MODE=$1
+APP_DIR=$(cd $2; pwd)
+
+## Update the repo.
+cd $APP_DIR
+git fetch --quiet origin 2>&1
+
+## Get some information about git.
+HIGHEST_TAG=$(git tag --list "*.*.*" | sort --version-sort | tail --lines 1)
+CURRENT_TAG=$(git describe --tags)
+CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
+DIFF_TO_MASTER=$(git diff origin/master)
+
+## Prod site: do nothing if we're already at the highest tag.
+if [[ $MODE == 'prod' && $CURRENT_TAG == $HIGHEST_TAG ]]; then
+    exit 0
+fi
+
+## Dev site: do nothing if not on master.
+if [[ $MODE == "dev" && $CURRENT_BRANCH != "master" ]]; then
+    ## Tell the maintainers, so they don't forget they're in
+    ## the middle of testing something.
+    echo "Dev site not on master branch. Not deploying."
+    exit 0
+fi
+
+## Dev site: do nothing if there's no difference to master.
+if [[ $MODE == "dev" && -z "$DIFF_TO_MASTER" ]]; then
+    exit 0
+fi
+
+## Update the code.
+if [[ $MODE == "prod" ]]; then
+    git checkout $HIGHEST_TAG
+fi
+if [[ $MODE == "dev" ]]; then
+    git pull origin master
+fi
+
+## Prod and dev sites: install the application.
+composer install --no-dev --optimize-autoloader
+./bin/console cache:clear
+./bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
This adds a generic deployment script for Toolforge deployments
with Kubernetes. It takes two parameters:

1. The environment to deploy, 'dev' or 'prod'. If the former,
   the latest code on the master branch will be installed; if
   the latter, only the latest tag will be installed.

2. The directory in which the tool is installed.

The code is based on the deploy.sh scripts for XTools and
Event Metrics.

Bug: T210888