### PR TITLE
Regenerate session ID when logging in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
+.idea/
 


### PR DESCRIPTION
The session ID should always be changed after any change in
privilege level.

This also throws a nicer error for when the request token is
not present (in the same way that it was already doing for
the verifier).

Bug: T219183