### PR TITLE
Sort Twig lang list by language code

### DIFF
--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -170,7 +170,7 @@ class Extension extends AbstractExtension
         foreach ($languages as $lang) {
             $availableLanguages[$lang] = $this->intuition->getLangName($lang);
         }
-        asort($availableLanguages);
+        ksort($availableLanguages);
         return $availableLanguages;
     }
 


### PR DESCRIPTION
Sort the array of languages by key instead of value, so that
language families are grouped near each other.

Bug: T219746