### PR TITLE
Add SAL logging

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -40,6 +40,10 @@ fi
 ## Update the code.
 if [[ $MODE == "prod" ]]; then
     git checkout $HIGHEST_TAG
+    ## Write to to the Server Admin Log on Wikitech if dologmsg is available.
+    if [[ $(command -v dologmsg) ]]; then
+        dologmsg "Updating to version $HIGHEST_TAG"
+    fi
 fi
 if [[ $MODE == "dev" ]]; then
     git pull origin master


### PR DESCRIPTION
Use the new 'dologmsg' command to add a log message when deploying
a new tag in production.