### PR TITLE
Verify that callback matches permitted prefix

### DIFF
--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AuthController extends AbstractController
 {
@@ -30,8 +31,13 @@ class AuthController extends AbstractController
             return $this->redirectToRoute('home');
         }
 
-        // Set the callback URL if given. Used to redirect back to target page after logging in.
-        if ($request->query->get('callback')) {
+        // Set the callback URL if given and if it matches the required prefix. If there's no
+        // prefix registered with the consumer then we can't supply our own callback.
+        // The prefixed callback is used to redirect back to target page after logging in.
+        $callback = $request->query->get('callback', '');
+        $callbackPrefix = $this->generateUrl('toolforge_oauth_callback', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $isPrefix = substr($callback, 0, strlen($callbackPrefix)) === $callbackPrefix;
+        if ($callback && $isPrefix) {
             $oauthClient->setCallback($request->query->get('callback'));
         }
 


### PR DESCRIPTION
OAuth callback URLs are only allowed to specify a custom callback
if they are prefixed with the registered callback, which in our
case is always the /oauth_callback one that we provide. This adds
a check for this when a custom callback URL is being supplied in
the query string, and if there's no match it defaults to what is
set in the OAuth consumer.

https://phabricator.wikimedia.org/T230085

Bug: T230085