### PR TITLE
Replace deprecated Session with RequestStack, for Symfony 5.3

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -18,7 +18,6 @@ services:
     factory: ['Wikimedia\ToolforgeBundle\Service\Intuition', serviceFactory]
     arguments:
       - "@request_stack"
-      - "@session"
       - "%kernel.project_dir%"
       - "%toolforge.intuition.domain%"
 
@@ -46,6 +45,6 @@ services:
   Wikimedia\ToolforgeBundle\Twig\Extension:
     arguments:
       - '@Krinkle\Intuition\Intuition'
-      - "@session"
+      - "@request_stack"
       - "%toolforge.intuition.domain%"
     tags: [ "twig.extension" ]

--- a/Service/Intuition.php
+++ b/Service/Intuition.php
@@ -6,21 +6,18 @@ namespace Wikimedia\ToolforgeBundle\Service;
 
 use Krinkle\Intuition\Intuition as KrinkleIntuition;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class Intuition extends KrinkleIntuition
 {
 
     /**
      * @param RequestStack $requestStack
-     * @param SessionInterface $session
      * @param string $projectDir Root filesystem directory of the application.
      * @param string $domain The i18n domain.
      * @return Intuition
      */
     public static function serviceFactory(
         RequestStack $requestStack,
-        SessionInterface $session,
         string $projectDir,
         string $domain
     ): Intuition {
@@ -31,6 +28,7 @@ class Intuition extends KrinkleIntuition
         if (null !== $requestStack->getCurrentRequest()) {
             // Use lang from the request or the session.
             $queryLang = $requestStack->getCurrentRequest()->query->get('uselang');
+            $session = $requestStack->getSession();
             $sessionLang = $session->get('lang');
             if (!empty($queryLang)) {
                 $useLang = $queryLang;

--- a/Service/Intuition.php
+++ b/Service/Intuition.php
@@ -26,19 +26,26 @@ class Intuition extends KrinkleIntuition
 
         // Current request doesn't exist in unit tests, in which case we'll fall back to English.
         if (null !== $requestStack->getCurrentRequest()) {
-            // Use lang from the request or the session.
-            $queryLang = $requestStack->getCurrentRequest()->query->get('uselang');
-            $session = $requestStack->getSession();
-            $sessionLang = $session->get('lang');
-            if (!empty($queryLang)) {
-                $useLang = $queryLang;
-            } elseif (!empty($sessionLang)) {
-                $useLang = $sessionLang;
+            $currentRequest = $requestStack->getCurrentRequest();
+            // Use lang from the 'lang' query parameter or the 'lang' session variable.
+            $queryLang = false;
+            if ($currentRequest->query->has('uselang')) {
+                $queryLang = $currentRequest->query->has('uselang');
+                if (!empty($queryLang)) {
+                    $useLang = $queryLang;
+                }
             }
-
-            // Save the language to the session.
-            if ($session->get('lang') !== $useLang) {
-                $session->set('lang', $useLang);
+            $sessionLang = false;
+            if ($currentRequest->hasSession()) {
+                $session = $currentRequest->getSession();
+                $sessionLang = $session->get('lang');
+                if (!empty($sessionLang)) {
+                    $useLang = $sessionLang;
+                }
+                // Save the language to the session.
+                if ($session->get('lang') !== $useLang) {
+                    $session->set('lang', $useLang);
+                }
             }
         }
 

--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Wikimedia\ToolforgeBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Wikimedia\ToolforgeBundle\Service\Intuition;
 use Wikimedia\ToolforgeBundle\Twig\Extension;
 
@@ -19,11 +21,14 @@ class ExtensionTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $session = new Session();
+        $requestStack = new RequestStack();
+        $request = new Request();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack->push($request);
         $domain = 'toolforge';
         $rootDir = dirname(__DIR__, 2);
-        $intuition = Intuition::serviceFactory(new RequestStack(), $session, $rootDir, $domain);
-        $this->extension = new Extension($intuition, new Session(), $domain);
+        $intuition = Intuition::serviceFactory($requestStack, $rootDir, $domain);
+        $this->extension = new Extension($intuition, $requestStack, $domain);
     }
 
     public function testBasics(): void

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -71,6 +71,9 @@ class Extension extends AbstractExtension
      */
     public function getLoggedInUser()
     {
+        if (!$this->session) {
+            return false;
+        }
         return $this->session->get('logged_in_user');
     }
 

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wikimedia\ToolforgeBundle\Twig;
 
 use NumberFormatter;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Process\Process;
 use Twig\Extension\AbstractExtension;
@@ -29,11 +30,11 @@ class Extension extends AbstractExtension
 
     public function __construct(
         Intuition $intuition,
-        Session $session,
+        RequestStack $requestStack,
         string $domain
     ) {
         $this->intuition = $intuition;
-        $this->session = $session;
+        $this->session = $requestStack->getSession();
         $this->domain = $domain;
     }
 

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -34,7 +34,9 @@ class Extension extends AbstractExtension
         string $domain
     ) {
         $this->intuition = $intuition;
-        $this->session = $requestStack->getSession();
+        if ($requestStack->getCurrentRequest() && $requestStack->getCurrentRequest()->hasSession()) {
+            $this->session = $requestStack->getCurrentRequest()->getSession();
+        }
         $this->domain = $domain;
     }
 


### PR DESCRIPTION
More info:
https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation

Bug: https://phabricator.wikimedia.org/T311024