### PR TITLE
Update slevomat/coding-standard and fix issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,28 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        php: [ '7.4', '8.0', '8.1' ]
+
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@1.0.0
+        uses: ludeeus/action-shellcheck@master
         with:
           scandir: './bin'
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: ${{matrix.php}}
 
       - name: Test
         run: |
           composer install
-          ./vendor/bin/phpcs
+          ./vendor/bin/phpcs -s
           SYMFONY_DEPRECATIONS_HELPER=disabled ./vendor/bin/simple-phpunit

--- a/Command/SshCommand.php
+++ b/Command/SshCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Wikimedia\ToolforgeBundle\Command;

--- a/Logger/WebRequestProcessor.php
+++ b/Logger/WebRequestProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Wikimedia\ToolforgeBundle\Logger;

--- a/Resources/phpcs/ruleset.xml
+++ b/Resources/phpcs/ruleset.xml
@@ -4,8 +4,9 @@
 
     <!-- Slevomat standards; see https://github.com/slevomat/coding-standard -->
     <config name="installed_paths" value="../../slevomat/coding-standard"/><!-- relative path from PHPCS source location -->
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessSuppress" />
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <exclude

--- a/Service/ReplicasClient.php
+++ b/Service/ReplicasClient.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Wikimedia\ToolforgeBundle\Service;

--- a/Tests/Service/ReplicasClientTest.php
+++ b/Tests/Service/ReplicasClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Wikimedia\ToolforgeBundle\Tests\Service;

--- a/Twig/Extension.php
+++ b/Twig/Extension.php
@@ -195,6 +195,7 @@ class Extension extends AbstractExtension
      * Whether the current (or specified) language is right-to-left.
      * @param string|bool $lang Language code (if false, will use current language).
      * @return bool
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function isRtl($lang = false): bool
     {
@@ -268,6 +269,7 @@ class Extension extends AbstractExtension
      * @param int|float $number
      * @param int $decimals Number of decimals to format to.
      * @return string
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
      */
     public function numberFormat($number, int $decimals = 0): string
     {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,12 @@
         "symfony/console": "^4.4|^5.2"
     },
     "require-dev": {
-        "slevomat/coding-standard": "^4.8",
+        "slevomat/coding-standard": "^8.0",
         "symfony/phpunit-bridge": "^4.4"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": false
+        }
     }
 }


### PR DESCRIPTION
* Also add more PHP versions in CI (and stop using PHP 7.2).
* Update GitHub Actions versions, to avoid deprecation warnings.
* Exclude the UselessSuppress sniff because we now test on both PHP 7 and 8, and parameter type hints are handled differently.

Bug: T318066