### PR TITLE
Cache Git commands for 10 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
 
     runs-on: ubuntu-latest
 
@@ -34,5 +34,4 @@ jobs:
       - name: Test
         run: |
           composer install
-          ./vendor/bin/phpcs -s
-          SYMFONY_DEPRECATIONS_HELPER=disabled ./vendor/bin/simple-phpunit
+          composer test

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -45,6 +45,7 @@ services:
   Wikimedia\ToolforgeBundle\Twig\Extension:
     arguments:
       - '@Krinkle\Intuition\Intuition'
+      - "@cache.app"
       - "@request_stack"
       - "%toolforge.intuition.domain%"
     tags: [ "twig.extension" ]

--- a/Tests/Twig/ExtensionTest.php
+++ b/Tests/Twig/ExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Wikimedia\ToolforgeBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -28,7 +29,8 @@ class ExtensionTest extends TestCase
         $domain = 'toolforge';
         $rootDir = dirname(__DIR__, 2);
         $intuition = Intuition::serviceFactory($requestStack, $rootDir, $domain);
-        $this->extension = new Extension($intuition, $requestStack, $domain);
+        $cache = new NullAdapter();
+        $this->extension = new Extension($intuition, $cache, $requestStack, $domain);
     }
 
     public function testBasics(): void

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,57 @@
 {
-    "name": "wikimedia/toolforge-bundle",
-    "description": "Symfony 4 bundle providing useful Toolforge features.",
-    "type": "symfony-bundle",
-    "license": "GPL-3.0-or-later",
-    "homepage": "https://github.com/wikimedia/toolforgebundle",
-    "support": {
-        "issues": "https://github.com/wikimedia/toolforgebundle/issues",
-        "source": "https://github.com/wikimedia/toolforgebundle",
-        "forum": "https://discourse-mediawiki.wmflabs.org/"
-    },
-    "authors": [
-        {
-            "name": "Sam Wilson",
-            "email": "sam@samwilson.id.au"
-        }
-    ],
-    "autoload": {
-        "psr-4": {
-            "Wikimedia\\ToolforgeBundle\\": "./"
-        }
-    },
-    "require": {
-        "ext-intl": "*",
-        "krinkle/intuition": "^2.3",
-        "mediawiki/oauthclient": "^1.0",
-        "symfony/config": "^4.4|^5.0",
-        "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/process": "^4.4|^5.0",
-        "symfony/routing": "^4.4|^5.0",
-        "symfony/twig-bridge": "^4.4|^5.0",
-        "twig/twig": "^2.4||^3.0",
-        "symfony/http-client": "^4.4|^5.0",
-        "symfony/cache": "^4.4|^5.0",
-        "doctrine/doctrine-bundle": "^2.2",
-        "symfony/dependency-injection": "^4.4|^5.1",
-        "symfony/console": "^4.4|^5.2"
-    },
-    "require-dev": {
-        "slevomat/coding-standard": "^8.0",
-        "symfony/phpunit-bridge": "^4.4"
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": false
-        }
-    }
+	"name": "wikimedia/toolforge-bundle",
+	"description": "Symfony 4 & 5 bundle providing useful Toolforge features.",
+	"type": "symfony-bundle",
+	"license": "GPL-3.0-or-later",
+	"homepage": "https://github.com/wikimedia/toolforgebundle",
+	"support": {
+		"issues": "https://phabricator.wikimedia.org/tag/toolforgebundle/",
+		"source": "https://github.com/wikimedia/toolforgebundle"
+	},
+	"authors": [
+		{
+			"name": "Sam Wilson",
+			"email": "sam@samwilson.id.au"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"Wikimedia\\ToolforgeBundle\\": "./"
+		}
+	},
+	"require": {
+		"ext-intl": "*",
+		"krinkle/intuition": "^2.3",
+		"mediawiki/oauthclient": "^1.0",
+		"symfony/config": "^4.4|^5.0",
+		"symfony/http-kernel": "^4.4|^5.0",
+		"symfony/process": "^4.4|^5.0",
+		"symfony/routing": "^4.4|^5.0",
+		"symfony/twig-bridge": "^4.4|^5.0",
+		"twig/twig": "^2.4||^3.0",
+		"symfony/http-client": "^4.4|^5.0",
+		"symfony/cache": "^4.4|^5.0",
+		"doctrine/doctrine-bundle": "^2.2",
+		"symfony/dependency-injection": "^4.4|^5.1",
+		"symfony/console": "^4.4|^5.2"
+	},
+	"require-dev": {
+		"slevomat/coding-standard": "^8.0",
+		"symfony/phpunit-bridge": "^4.4"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": false
+		}
+	},
+	"scripts": {
+		"test": [
+			"composer validate",
+			"phpcs -s .",
+			"simple-phpunit"
+		],
+		"fix": [
+			"phpcbf"
+		]
+	}
 }


### PR DESCRIPTION
* Cache the output of the Git Twig commands for ten minutes.
* Fix issues link in composer.json
* Add test script to composer.json and use it from github CI config.

Bug: T334454