### PR TITLE
SshCommand: QoL improvements

### DIFF
--- a/Command/SshCommand.php
+++ b/Command/SshCommand.php
@@ -99,6 +99,15 @@ class SshCommand extends Command
 
         $slices = array_unique(array_values($this->client->getDbList()));
         $processArgs = ['ssh', '-N'];
+
+        if ($output->isVerbose()) {
+            $processArgs[] = '-v';
+        } elseif ($output->isVeryVerbose()) {
+            $processArgs[] = '-vv';
+        } elseif ($output->isDebug()) {
+            $processArgs[] = '-vvv';
+        }
+
         foreach ($slices as $slice) {
             $processArgs[] = '-L';
             $arg = $this->client->getPortForSlice($slice).":$slice.$host:3306";

--- a/Command/SshCommand.php
+++ b/Command/SshCommand.php
@@ -110,7 +110,11 @@ class SshCommand extends Command
         if ($toolsDb) {
             $processArgs[] = '-L';
             $port = $this->client->getPortForSlice('toolsdb');
-            $processArgs[] = $port.':tools'.self::HOST_SUFFIX.':3306';
+            $arg = $port.':tools'.self::HOST_SUFFIX.':3306';
+            if ($bindAddress) {
+                $arg = $bindAddress.':'.$arg;
+            }
+            $processArgs[] = $arg;
         }
         $processArgs[] = $login;
 


### PR DESCRIPTION
Two main changes:
* Make `--toolsdb` connection respect the `--bind-address` if specified.
* Pass the verbosity requested by the user into the `ssh` command.
  * `-v` enables `debug1` messages, `-vv` enables `debug2` messages, and `-vvv` enables `debug3` messages.
  * Helpful for debugging some connection issues.