### PR TITLE
Add support to connect to a Trove database

### DIFF
--- a/Command/SshCommand.php
+++ b/Command/SshCommand.php
@@ -72,6 +72,12 @@ class SshCommand extends Command
             InputOption::VALUE_NONE,
             'Sets up an SSH tunnel to tools.db.svc.wikimedia.cloud'
         );
+        $this->addOption(
+            'trove',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Sets up an SSH tunnel to a Trove database. Provide the hostname of the Trove database to connect to.'
+        );
     }
 
     /**
@@ -86,6 +92,7 @@ class SshCommand extends Command
         $service = $input->getOption('service');
         $bindAddress = $input->getOption('bind-address');
         $toolsDb = $input->getOption('toolsdb');
+        $trove = $input->getOption('trove');
         $host = "$service".self::HOST_SUFFIX;
         $login = $username ? $username.'@'.self::LOGIN_URL : self::LOGIN_URL;
 
@@ -115,6 +122,15 @@ class SshCommand extends Command
             $processArgs[] = '-L';
             $port = $this->client->getPortForSlice('toolsdb');
             $arg = $port.':tools'.self::HOST_SUFFIX.':3306';
+            if ($bindAddress) {
+                $arg = $bindAddress.':'.$arg;
+            }
+            $processArgs[] = $arg;
+        }
+        if ($trove) {
+            $processArgs[] = '-L';
+            $port = $this->client->getPortForSlice('trove');
+            $arg = "$port:$trove:3306";
             if ($bindAddress) {
                 $arg = $bindAddress.':'.$arg;
             }

--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ doctrine:
         port: '%env(TOOLSDB_PORT)%'
         user: '%env(TOOLSDB_USERNAME)%'
         password: '%env(TOOLSDB_PASSWORD)%'
+      # If you need to work with a Trove database
+      toolforge_trove:
+        host: '%env(TROVE_HOST)%'
+        port: '%env(TROVE_PORT)%'
+        user: '%env(TROVE_USERNAME)%'
+        password: '%env(TROVE_PASSWORD)%'
 ```
 
 </details>
@@ -294,6 +300,10 @@ If you need to work against [tools-db](https://wikitech.wikimedia.org/wiki/Help:
 pass the `--toolsdb` flag and make sure the `TOOLSBD_` env variables are set correctly.
 Unless you have a private database, you should be able to use the same username and password
 as `REPLICAS_USERNAME` and `REPLICAS_PASSWORD`.
+
+If you need to work against a [Trove database](https://wikitech.wikimedia.org/wiki/Help:Trove_database_user_guide),
+pass the `--trove` flag, supplying the hostname, and make sure the `TROVE_` env variables are set correctly.
+The credentials for this are separate from the replicas and toolsdb.
 
 To query the replicas, inject the `ReplicasClient` service then call the `getConnection()`
 method, passing in a valid database, and you should get a `Doctrine\DBAL\Connection` object.


### PR DESCRIPTION
Several clients (or would-be clients) connect to a WMCS Trove database, as opposed to using tools-db. This is customary for any VPS tool.

Theoretically we could just allow the --toolsdb to take a hostname, and use that and the TOOLSDB_ env variables to accomplish the same thing, but tools could need to connect to both.