### PR TITLE
Update phpunit and mediawiki/oauthclient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	},
 	"require-dev": {
 		"slevomat/coding-standard": "^8.0",
-		"symfony/phpunit-bridge": "^4.4"
+		"symfony/phpunit-bridge": "^4.4|^5.1"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	"require": {
 		"ext-intl": "*",
 		"krinkle/intuition": "^2.3",
-		"mediawiki/oauthclient": "^1.0",
+		"mediawiki/oauthclient": "^2.0",
 		"symfony/config": "^4.4|^5.0",
 		"symfony/http-kernel": "^4.4|^5.0",
 		"symfony/process": "^4.4|^5.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
         convertWarningsToExceptions="true"
         bootstrap="./vendor/autoload.php">
 
+    <php>
+        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+    </php>
+
     <testsuites>
         <testsuite name="Test suite">
             <directory>./Tests</directory>


### PR DESCRIPTION
This drops support for PHP 7.3 and earlier, which we didn't support anyway.

Also fixes an issue with running phpunit on PHP 7.4.