### PR TITLE
Use Route attributes for controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '8.0', '8.1', '8.2', '8.3' ]
 
     runs-on: ubuntu-latest
 

--- a/Command/SshCommand.php
+++ b/Command/SshCommand.php
@@ -19,9 +19,6 @@ use Wikimedia\ToolforgeBundle\Service\ReplicasClient;
 class SshCommand extends Command
 {
 
-    /** @var string */
-    protected static $defaultName = 'toolforge:ssh';
-
     /** @var ReplicasClient */
     protected $client;
 
@@ -38,7 +35,7 @@ class SshCommand extends Command
     public function __construct(ReplicasClient $client)
     {
         $this->client = $client;
-        parent::__construct();
+        parent::__construct('toolforge:ssh');
     }
 
     /**

--- a/Controller/AuthController.php
+++ b/Controller/AuthController.php
@@ -9,7 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AuthController extends AbstractController
@@ -17,9 +17,9 @@ class AuthController extends AbstractController
 
     /**
      * Redirect to Meta for Oauth authentication.
-     * @Route("/login", name="toolforge_login")
      * @return RedirectResponse
      */
+    #[Route("/login", name:"toolforge_login")]
     public function loginAction(Request $request, Client $oauthClient, Session $session): RedirectResponse
     {
         // Automatically log in a development user if defined.
@@ -53,10 +53,10 @@ class AuthController extends AbstractController
 
     /**
      * Receive authentication credentials back from the OAuth wiki.
-     * @Route("/oauth_callback", name="toolforge_oauth_callback")
      * @param Request $request The HTTP request.
      * @return RedirectResponse
      */
+    #[Route("/oauth_callback", name:"toolforge_oauth_callback")]
     public function oauthCallbackAction(Request $request, Session $session, Client $client): RedirectResponse
     {
         // Give up if the required GET params or stored request token don't exist.
@@ -94,9 +94,9 @@ class AuthController extends AbstractController
 
     /**
      * Log out the user and return to the homepage.
-     * @Route("/logout", name="toolforge_logout")
      * @return RedirectResponse
      */
+    #[Route("/logout", name:"toolforge_logout")]
     public function logoutAction(Session $session): RedirectResponse
     {
         $session->invalidate();

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Toolforge Bundle
 ================
 
-A Symfony 4/5 bundle that provides some common parts of web-based tools in Wikimedia Toolforge.
+A Symfony 5/6/7 bundle that provides some common parts of web-based tools in Wikimedia Toolforge.
 
 Features:
 

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -1,3 +1,3 @@
 toolforge_oauth:
-    resource: "@ToolforgeBundle/Controller/"
-    type: attribute
+	resource: "@ToolforgeBundle/Controller/"
+	type: attribute

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -1,3 +1,3 @@
 toolforge_oauth:
-  resource: "@ToolforgeBundle/Controller/"
-  type: annotation
+    resource: "@ToolforgeBundle/Controller/"
+    type: attribute

--- a/Resources/config/routes.yaml
+++ b/Resources/config/routes.yaml
@@ -1,3 +1,3 @@
 toolforge_oauth:
-	resource: "@ToolforgeBundle/Controller/"
-	type: attribute
+  resource: "@ToolforgeBundle/Controller/"
+  type: attribute


### PR DESCRIPTION
* Switch to using Route attributes for the AuthController.
* Move the SshCommand's name to a constructor parameter instead of as the $defaultName value.
* Drop testing on PHP 7.4.

Bug: T361554